### PR TITLE
fix: removes extra employee mikael from employee list

### DIFF
--- a/src/employees/utils/getStaticProps.ts
+++ b/src/employees/utils/getStaticProps.ts
@@ -1,14 +1,13 @@
-import { getContactsByEmails, getEmployeesByOffice } from "./getEmployeesList";
+import { getEmployeesByOffice } from "./getEmployeesList";
 
 export async function getStaticPropsEmployees() {
   // Set so we can run local as fallback.
   const employeeList = await getEmployeesByOffice("stockholm");
-  const extraEmployee = await getContactsByEmails(["mb@variant.no"]);
 
   if (employeeList) {
     return {
       props: {
-        employeeList: employeeList.concat(extraEmployee),
+        employeeList,
       },
       revalidate: 24 * 60 * 60,
     };


### PR DESCRIPTION
We used to explicitly add me to show a greater network in Norway for developers. No longer the same need, so proposing to remove me from the employee listing.