### PR TITLE
fix: reduces reduntant email domain and thus width of emails

### DIFF
--- a/src/employees/employees.module.css
+++ b/src/employees/employees.module.css
@@ -98,10 +98,11 @@
 
 .employee__phone {
   text-decoration: none;
-  font-size: 1rem;
+  font-size: 0.8rem;
   color: var(--color-standard__white--text);
   padding: 0.6rem 1.2rem;
   line-height: 1;
+  overflow: hidden;
 
   background: linear-gradient(
     to right,

--- a/src/employees/index.tsx
+++ b/src/employees/index.tsx
@@ -46,8 +46,8 @@ export default function Employees({
         <header className={style.employees__header}>
           <PageTitle title={"Alla varianter"} />
           <p className={style.employees__text}>
-            Vill du jobba med oss? Eller är du intresserad av någon av våra tjänster? 
-            👋 Don&apos;t be a stranger. 
+            Vill du jobba med oss? Eller är du intresserad av någon av våra
+            tjänster? 👋 Don&apos;t be a stranger.
           </p>
         </header>
 
@@ -104,8 +104,12 @@ export const EmployeeTile: React.FC<{ employee: EmployeeItem }> = ({
           📞 {formatTelephone(telephone)}
         </a>
       ) : (
-        <a href={`mailto:${email}`} className={style.employee__phone}>
-          📧 {email}
+        <a
+          href={`mailto:${email}`}
+          title={email}
+          className={style.employee__phone}
+        >
+          📧 {email.replace("@variant.se", "")}
         </a>
       )}
     </div>


### PR DESCRIPTION
In some cases, the email is very long. Causing the layout to break. We could rewrite the layout making it support wider email, but still, it is causing some textual imbalance I think. 

This removes the redundant `@variant.se` after each email and reduces the size somewhat. Link will still function and the title/hover will show the full email.

<img width="1115" alt="Screenshot 2023-10-11 at 14 17 12" src="https://github.com/varianter/variant.se/assets/606374/6e00baee-3958-445e-bd53-fb192765c7dc">
