### PR TITLE
Add Linköping to office selector

### DIFF
--- a/src/employees/index.tsx
+++ b/src/employees/index.tsx
@@ -75,6 +75,7 @@ export default function Employees({
             officeMap={{
               Alla: '/varianter',
               Göteborg: '/varianter/goteborg',
+              Linköping: '/varianter/linkoping',
               Stockholm: '/varianter/stockholm',
             }}
           />

--- a/src/jobs/utils/getListings.ts
+++ b/src/jobs/utils/getListings.ts
@@ -110,6 +110,8 @@ function officeToDepartmentRegex(department: Office) {
   switch (department) {
     case 'goteborg':
       return /(goteborg|göteborg)/i;
+    case 'linkoping':
+      return /(linkoping|linköping)/i;
     case 'stockholm':
       return /stockholm/i;
   }

--- a/src/office-selector/index.tsx
+++ b/src/office-selector/index.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import style from './office.module.css';
 
-export const offices = ['goteborg', 'stockholm'] as const;
+export const offices = ['goteborg', 'linkoping', 'stockholm'] as const;
 export type Office = typeof offices[number];
 
 export function stringToDepartment(dep?: string): Office | undefined {


### PR DESCRIPTION
Employees from Linköping are missing in bemanning, so this should be added before including in the office selector.