### PR TITLE
Fix overlapping employee blobs

### DIFF
--- a/src/employees/employees.module.css
+++ b/src/employees/employees.module.css
@@ -15,15 +15,16 @@
 }
 
 .employees__layout {
-  --image-width: 400px;
+  --image-width: 300px;
   --column-margin: 0.8rem;
   --columns: 1;
 
   --total-margin: calc(var(--column-margin) * 2 * var(--columns));
   --total-images-width: calc(var(--image-width) * var(--columns));
 
-  max-width: calc(var(--total-images-width) + var(--total-margin));
+  max-width: calc(var(--total-images-width) + var(--total-margin) + 5rem);
   display: flex;
+  justify-content: space-evenly;
   flex-wrap: wrap;
   padding-top: 4rem;
   padding-bottom: 10rem;
@@ -31,8 +32,7 @@
 
 .employee {
   /* Add margin based on a random offset to make it look more random. */
-  margin: calc(-4rem + 1rem * var(--randomOffset))
-    calc(1rem - 1rem * var(--randomOffset));
+  margin-top: calc(-2rem + 1rem * var(--randomOffset));
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -46,7 +46,7 @@
   color: var(--color-primary__tint1--text);
 }
 
-@media (max-width: 990px) {
+@media (max-width: 760px) {
   .employee {
     margin: 0;
   }
@@ -86,11 +86,10 @@
 
 .employee__phone {
   text-decoration: none;
-  font-size: 0.8rem;
+  font-size: 1rem;
   color: var(--color-standard__white--text);
   padding: 0.6rem 1.2rem;
   line-height: 1;
-  overflow: hidden;
 
   background: linear-gradient(
     to right,

--- a/src/employees/index.tsx
+++ b/src/employees/index.tsx
@@ -7,7 +7,7 @@ import Head from 'next/head';
 import Image from 'next/image';
 import Link from 'next/link';
 import { getStaticProps } from 'pages/varianter';
-import React, { CSSProperties, useEffect, useState } from 'react';
+import React, { CSSProperties, PropsWithChildren, useEffect, useState } from 'react';
 import Layout from 'src/layout';
 import { and } from 'src/utils/css';
 import style from './employees.module.css';
@@ -112,11 +112,12 @@ export default function Employees({
 const blurDataUrl =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADQAAAA0CAYAAADFeBvrAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAIHSURBVHgB7dhBbtNAFAbg/40lJHa9AbbgAL0BZoNkWpTmBOQIcIIoN6AnoD1BWlCxxAZzgoZ9JZsbZFkqeR4zJF0ggei8mYkqeN8yiyS/38yb8QOUUkoppf4bhMTaD31NhIkF1+7L99xH5faH1gysCHzOhTlrmmpABskCtRf9nJhf8ybEHX6ZT2DMInWw6ECfLvr9kXmJbSUCDQXR9PlBtUIiBhE+vr86ssyfIQvjle5hXLbtt1dIRFyhbWUukUpRzJrm0SkiiQK1bV9ijKrM7/7I2hA9i11+oiVH1s6RMIznm4nfi8tlf7em8gfBgXx1mGmGPMqHD+w7RAivkB1rZOQe1pE/yyAUHIhAE+RGPIdQeIWYSuRXS6sUHMht3n3shK0hEHWwZkX0FAL3N5DwWJAEGrAbJQQEXQ5r3GPBgdxl9At2Y4BAeIUMJ7vq/8UAgeBA1zfFGXaAmb9CIDjQdFq5PUQdMiNjRCtB1rYZC+Rm0EFAFKh5WXU5q+Q66Uo6a5AfrBmrxETHEBIH8lVi8BukN1zfQNx4oq4+Lw4fv3UnU/Qc4BdEi03jkYm+yzWHT2auxyZZfq5VHzcH1QkiJBw0XrlgJmLWYE9/PpxI6UfBgcH83dCNjReb5RsveaBbfm5nGbV7IZy4efbe7Yvhdsa9dnul43E8/z4WXcyeUUoppZRS/44fYomy++H/LMkAAAAASUVORK5CYII=';
 
-export const EmployeeTile: React.FC<{
-  employee: EmployeeItem;
-  photoSize?: number;
-}> = ({ employee: { name, telephone, email, imageUrl, officeName } }) => {
-  const useResponsiveLayout = useMediaQuery(`(max-width: 990px)`) ?? true;
+export const EmployeeTile = ({
+  employee: { name, telephone, email, imageUrl, officeName },
+}: PropsWithChildren<{ employee: EmployeeItem }>) => {
+  if (!imageUrl) {
+    return null;
+  }
 
   return (
     <div
@@ -124,8 +125,8 @@ export const EmployeeTile: React.FC<{
       style={{ '--randomOffset': getRandomOffset() } as CSSProperties}
     >
       <Image
-        width={useResponsiveLayout ? 200 : 300}
-        height={useResponsiveLayout ? 200 : 300}
+        width={300}
+        height={300}
         alt={`Bild på ${name}`}
         src={imageUrl}
         loading="lazy"
@@ -162,8 +163,6 @@ function getRandomOffset() {
 }
 
 function JobsLink({ text }: { text: string }) {
-  const useResponsiveLayout = useMediaQuery(`(max-width: 990px)`) ?? true;
-
   return (
     <div
       className={style.employee__jobsLinkContainer}
@@ -172,8 +171,8 @@ function JobsLink({ text }: { text: string }) {
       <Link href="/jobs">
         <a className={style.employee__jobsLink}>
           <BaseBlob
-            width={useResponsiveLayout ? 300 : 400}
-            height={useResponsiveLayout ? 300 : 400}
+            width={300}
+            height={300}
             randomness={2}
             extraPoints={6}
             color={colors.colorPairs.secondary1.default.bg}


### PR DESCRIPTION
Slightly adjusted employees page to match grid styling from [variant.no](https://github.com/varianter/variant.no) and avoid blobs overlapping

Before             |  After
:-------------------------:|:-------------------------:
<img width="757" alt="image" src="https://github.com/user-attachments/assets/f72e5b16-8f19-44d5-ace4-4082995ae7e4"> | <img width="760" alt="image" src="https://github.com/user-attachments/assets/d38c4999-2f29-4965-9bc7-c72bbd6e359c">
